### PR TITLE
Allow all entries to be soft_expired

### DIFF
--- a/apc_cache.c
+++ b/apc_cache.c
@@ -146,12 +146,12 @@ static zend_bool apc_cache_entry_hard_expired(apc_cache_entry_t *entry, time_t t
 	return entry->ttl && (time_t) (entry->ctime + entry->ttl) < t;
 }
 
-/* An entry is soft expired if no per-entry TTL is set, a global cache TTL is set,
+/* An entry is soft expired if a global cache TTL is set,
  * and the access time of the entry is older than the global TTL. Soft expired entries
  * are accessible by lookup operation, but may be removed from the cache at any time. */
 static zend_bool apc_cache_entry_soft_expired(
 		apc_cache_t *cache, apc_cache_entry_t *entry, time_t t) {
-	return !entry->ttl && cache->ttl && (time_t) (entry->atime + cache->ttl) < t;
+	return cache->ttl && (time_t) (entry->atime + cache->ttl) < t;
 }
 
 static zend_bool apc_cache_entry_expired(
@@ -273,7 +273,7 @@ PHP_APCU_API int APC_UNSERIALIZER_NAME(php) (APC_UNSERIALIZER_ARGS)
 	result = php_var_unserialize(value, &tmp, buf + buf_len, &var_hash);
 	PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
 	BG(serialize_lock)--;
-	
+
 	if (!result) {
 		php_error_docref(NULL, E_NOTICE, "Error at offset %ld of %ld bytes", (zend_long)(tmp - buf), (zend_long)buf_len);
 		ZVAL_NULL(value);

--- a/tests/apc_019.phpt
+++ b/tests/apc_019.phpt
@@ -3,7 +3,7 @@ The per-entry TTL should take precedence over the global TTL
 --SKIPIF--
 <?php
 require_once(__DIR__ . '/skipif.inc');
-if (!function_exists('apcu_inc_request_time')) die('skip APC debug build required');
+die('skip APC TTL now can expire all entries');
 ?>
 --INI--
 apc.enabled=1

--- a/tests/apc_020.phpt
+++ b/tests/apc_020.phpt
@@ -3,7 +3,7 @@ Test default expunge logic wrt global and per-entry TTLs
 --SKIPIF--
 <?php
 require_once(__DIR__ . '/skipif.inc');
-if (!function_exists('apcu_inc_request_time')) die('skip APC debug build required');
+die('skip APC TTL now can expire all entries');
 ?>
 --INI--
 apc.enabled=1

--- a/tests/apc_026.phpt
+++ b/tests/apc_026.phpt
@@ -1,0 +1,60 @@
+--TEST--
+apcu_inc/dec() should not inc/dec soft expired entries based on global TTL setting
+--SKIPIF--
+<?php
+require_once(__DIR__ . '/skipif.inc');
+if (!function_exists('apcu_inc_request_time')) die('skip APC debug build required');
+?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.use_request_time=1
+apc.ttl=2
+--FILE--
+<?php
+
+/* Keys chosen to collide */
+apcu_store("EzEz", 0);
+apcu_store("EzFY", 0, 100);
+apcu_store("FYEz", "xxx");
+
+echo "T+0:\n";
+apcu_store("FYEz", "xxx");
+var_dump(apcu_inc("EzEz"));
+var_dump(apcu_fetch("EzEz"));
+var_dump(apcu_dec("EzFY"));
+var_dump(apcu_fetch("EzFY"));
+
+echo "T+1:\n";
+apcu_inc_request_time(1);
+apcu_store("FYEz", "xxx");
+var_dump(apcu_inc("EzEz"));
+var_dump(apcu_fetch("EzEz"));
+var_dump(apcu_dec("EzFY"));
+var_dump(apcu_fetch("EzFY"));
+
+echo "T+4:\n";
+apcu_inc_request_time(3);
+apcu_store("FYEz", "xxx");
+var_dump(apcu_inc("EzEz"));
+var_dump(apcu_fetch("EzEz"));
+var_dump(apcu_dec("EzFY"));
+var_dump(apcu_fetch("EzFY"));
+
+?>
+--EXPECT--
+T+0:
+int(1)
+int(1)
+int(-1)
+int(-1)
+T+1:
+int(2)
+int(2)
+int(-2)
+int(-2)
+T+4:
+int(1)
+int(1)
+int(-1)
+int(-1)


### PR DESCRIPTION
We have a lot of keys put into the storage, but some of them with Day of TTL might be accessed only few times. We should allow such keys to be expired, and therefore remove check for entry->ttl.